### PR TITLE
reduce the padding for the input area to show the preview side-by-side of the form

### DIFF
--- a/src/css/studio.css
+++ b/src/css/studio.css
@@ -56,6 +56,11 @@ a {
   padding: 24px;
 }
 
+#inputs {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 #header {
   background-color: #33B5E5;
   color: #fff;
@@ -385,7 +390,7 @@ button {
   background-color: #33b5e5;
   border: 1px solid #33b5e5;
   cursor: pointer;
-  
+
   margin-left: 12px;
   vertical-align: middle;
 }


### PR DESCRIPTION
In some browsers (chrome Version 33.0.1750.146, Firefox 29.0) the preview is not showing side by side, instead it is shown after the form (with right floating).

This should fix that.
